### PR TITLE
fixed random crash IllegalArgumentException: pointerIndex out of range

### DIFF
--- a/library/src/main/java/com/kodmap/app/library/ui/KmViewPager.kt
+++ b/library/src/main/java/com/kodmap/app/library/ui/KmViewPager.kt
@@ -34,7 +34,7 @@ class KmViewPager : ViewPager {
 
     override fun canScrollHorizontally(direction: Int): Boolean {
         try {
-            return !swipeLocked && super.canScrollHorizontally(event)
+            return !swipeLocked && super.canScrollHorizontally(direction)
         }catch (e: java.lang.Exception) {
             return !swipeLocked
         }

--- a/library/src/main/java/com/kodmap/app/library/ui/KmViewPager.kt
+++ b/library/src/main/java/com/kodmap/app/library/ui/KmViewPager.kt
@@ -17,15 +17,27 @@ class KmViewPager : ViewPager {
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        return !swipeLocked && super.onTouchEvent(event)
+        try {
+            return !swipeLocked && super.onTouchEvent(event)
+        }catch (e: java.lang.Exception) {
+            return !swipeLocked
+        }
     }
 
     override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
-        return !swipeLocked && super.onInterceptTouchEvent(event)
+        try {
+            return !swipeLocked && super.onInterceptTouchEvent(event)
+        }catch (e: java.lang.Exception) {
+            return !swipeLocked
+        }
     }
 
     override fun canScrollHorizontally(direction: Int): Boolean {
-        return !swipeLocked && super.canScrollHorizontally(direction)
+        try {
+            return !swipeLocked && super.canScrollHorizontally(event)
+        }catch (e: java.lang.Exception) {
+            return !swipeLocked
+        }
     }
 
 


### PR DESCRIPTION
 java.lang.IllegalArgumentException: pointerIndex out of range
        at android.view.MotionEvent.nativeGetAxisValue(Native Method)
        at android.view.MotionEvent.getX(MotionEvent.java:2608)
        at androidx.viewpager.widget.ViewPager.onInterceptTouchEvent(ViewPager.java:2072)
        at com.kodmap.app.library.ui.KmViewPager.onInterceptTouchEvent(KmViewPager.kt:24)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:3341)

ref: https://github.com/chrisbanes/PhotoView/issues/31#issuecomment-19803926